### PR TITLE
Fix --get-archive=arc not waiting for ACK

### DIFF
--- a/main.c
+++ b/main.c
@@ -382,7 +382,9 @@ int main(int argc, char *argv[])
         exit(2);
       }
 
-      printf("Sending time for archive download\n");
+      if (bVerbose) {
+    	  printf("Sending time for archive download\n");
+      }
       datetimeString[6] = '\n';
       if (runCommand(datetimeString, 6, 6, "archive download initiation", true, true)) {
         exit(2);


### PR DESCRIPTION
After the DMPAFT command has been sent and the ACK has been received, the driver was sending the date and was waiting for the ACK only for a few CPU cycles, not enough for the davis to process the request. A separate ReadBufferWithTimeout function was added to block the execution and wait for the incomming bytes before timing out.